### PR TITLE
Add macOS support to server.py and client.py

### DIFF
--- a/client.py
+++ b/client.py
@@ -17,7 +17,7 @@ class clientType:
     client = ''
 
     def __init__(self):
-        if platform == "linux" or platform == "linux2":
+        if platform == "linux" or platform == "linux2" or platform == "darwin":
             os.system('clear')
         elif platform == "win32":
             os.system('cls')

--- a/server.py
+++ b/server.py
@@ -16,7 +16,7 @@ class serverType:
     server = ''
 
     def __init__(self):
-        if platform == "linux" or platform == "linux2":
+        if platform == "linux" or platform == "linux2" or platform == "darwin":
             os.system('clear')
             if (os.path.exists('ip.txt')):
                 os.remove('ip.txt')


### PR DESCRIPTION
Hi there,

adding macOS support is not that difficult, as macOS itself is based on darwin, which is a mostly POSIX-compliant operating system. This means, that the CLI commands executed on Linux machines at the beginning of both files are also supported under macOS itself. To support macOS, it is sufficient to add a check for Darwin to the already existing Linux check. I have implemented this in my pull request and verified it on my Mac, where everything is working as it should.